### PR TITLE
Fix React version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Daily Life Gamified App
+
+This project is an Expo application built with TypeScript. To run the project locally you will need Node.js installed.
+
+```bash
+npm install
+npm run android   # or npm run ios or npm run web
+```
+
+Expo will start the Metro bundler and provide instructions for running the app on your target device. Ensure the Expo CLI is installed globally if the `expo` command is not found.

--- a/daily-life-gamified-app/package.json
+++ b/daily-life-gamified-app/package.json
@@ -14,12 +14,12 @@
     "@react-navigation/native-stack": "^7.3.14",
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
-    "react": "19.0.0",
+    "react": "18.2.0",
     "react-native": "0.79.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@types/react": "~19.0.10",
+    "@types/react": "~18.2.21",
     "typescript": "~5.8.3"
   },
   "private": true


### PR DESCRIPTION
## Summary
- update React to 18.2 in package.json to match Expo versions
- document setup commands for using Expo

## Testing
- `npm test` *(fails: Missing script)*
- `npm run web` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad65567748332b9e7831e21ffb513